### PR TITLE
Add enp* to the list of allowed BIRD interfaces

### DIFF
--- a/templates/icehouse/bird.conf
+++ b/templates/icehouse/bird.conf
@@ -29,7 +29,7 @@ protocol device {
 
 protocol direct {
    debug all;
-   interface "-dummy0", "dummy1", "eth*", "em*", "br*", "juju-br*", "ens*";
+   interface "-dummy0", "dummy1", "eth*", "em*", "br*", "juju-br*", "ens*", "enp*";
 }
 
 # Peer with all neighbours.

--- a/templates/icehouse/bird6.conf
+++ b/templates/icehouse/bird6.conf
@@ -29,7 +29,7 @@ protocol device {
 
 protocol direct {
    debug all;
-   interface "-dummy0", "dummy1", "eth*", "em*", "br*", "juju-br*", "ens*";
+   interface "-dummy0", "dummy1", "eth*", "em*", "br*", "juju-br*", "ens*", "enp*";
 }
 
 # Peer with all neighbours.


### PR DESCRIPTION
  enp* appears on few Dell servers (OS: 16.04-xenial)

Signed-off-by: Junaid Ali <junaidali.yahya@gmail.com>